### PR TITLE
[Sentry] self-hosted and configuration support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,18 @@
   ],
   "require": {
     "php": "^8.1",
-    "illuminate/console": "^9.48",
-    "illuminate/http": "^9.48",
-    "illuminate/support": "^9.48"
+    "illuminate/console": "^9.0",
+    "illuminate/http": "^9.0",
+    "illuminate/support": "^9.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.13",
     "phpstan/phpstan": "^1.9",
     "rector/rector": "^0.14.8",
     "orchestra/testbench": "^7.17",
-    "guzzlehttp/guzzle": "^7.5"
+    "guzzlehttp/guzzle": "^7.5",
+    "sentry/sentry": "^3.12.1",
+    "php-http/guzzle7-adapter": "^1.0"
   },
   "suggests": {
     "sentry/sentry-laravel": "^3.1"

--- a/src/Console/SentryCommand.php
+++ b/src/Console/SentryCommand.php
@@ -7,7 +7,6 @@ use Illuminate\Console\Command;
 
 class SentryCommand extends Command
 {
-
     protected $signature = 'schedule:monitor:sentry {uuid} {--dsn=} {--error}';
 
     protected $description = 'Dispatch a signal to Sentry cron monitoring';
@@ -34,5 +33,4 @@ class SentryCommand extends Command
 
         return self::SUCCESS;
     }
-
 }

--- a/src/Console/SentryCommand.php
+++ b/src/Console/SentryCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Goedemiddag\ScheduleMonitor\Console;
+
+use Goedemiddag\ScheduleMonitor\SentryReporter;
+use Illuminate\Console\Command;
+
+class SentryCommand extends Command
+{
+
+    protected $signature = 'schedule:monitor:sentry {uuid} {--dsn=} {--error}';
+
+    protected $description = 'Dispatch a signal to Sentry cron monitoring';
+
+    public function handle()
+    {
+        $reporter = new SentryReporter($this->argument('uuid'), $this->option('dsn'));
+
+        if (!$reporter->shouldReport()) {
+            $this->error("Can't report: missing Monitor ID or DSN");
+            return self::FAILURE;
+        }
+
+        $reporter->inProgress();
+
+        if ($this->option('error')) {
+            $reporter->failed();
+        } else {
+            $reporter->success();
+        }
+
+        return self::SUCCESS;
+    }
+
+}

--- a/src/Console/SentryCommand.php
+++ b/src/Console/SentryCommand.php
@@ -12,8 +12,11 @@ class SentryCommand extends Command
 
     protected $description = 'Dispatch a signal to Sentry cron monitoring';
 
-    public function handle()
+    public function handle(): int
     {
+        assert(is_string($this->argument('uuid')), 'UUID must be a string');
+        assert(is_string($this->option('dsn')) || is_null($this->option('dsn')), 'DSN must be a string or omitted');
+
         $reporter = new SentryReporter($this->argument('uuid'), $this->option('dsn'));
 
         if (!$reporter->shouldReport()) {

--- a/src/Exceptions/DependencyMissingException.php
+++ b/src/Exceptions/DependencyMissingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Goedemiddag\ScheduleMonitor\Exceptions;
+
+class DependencyMissingException extends \RuntimeException implements ScheduleMonitoringException
+{
+}

--- a/src/Exceptions/ScheduleMonitoringException.php
+++ b/src/Exceptions/ScheduleMonitoringException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Goedemiddag\ScheduleMonitor\Exceptions;
+
+interface ScheduleMonitoringException
+{
+}

--- a/src/SentryReporter.php
+++ b/src/SentryReporter.php
@@ -2,41 +2,84 @@
 
 namespace Goedemiddag\ScheduleMonitor;
 
+use Closure;
+use Goedemiddag\ScheduleMonitor\Exceptions\DependencyMissingException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
+use Sentry\Dsn;
 
 class SentryReporter implements JobReporter
 {
-    protected readonly string $dsn;
-
+    protected static ?Closure $resolveDsnCallback;
 
     public function __construct(
         protected readonly ?string $monitorId,
+        protected readonly ?string $dsn = null,
     ) {
-        $dsn = config('sentry.dsn');
-
-        if (is_string($dsn) && !empty($dsn)) {
-            $this->dsn = $dsn;
+        if (!class_exists(Dsn::class)) {
+            throw new DependencyMissingException('Sentry\\Dsn not found. Install sentry/sentry or sentry/sentry-laravel to use this driver.');
         }
     }
 
-
     private function http(): PendingRequest
     {
-        return Http::baseUrl("https://sentry.io/api/0/monitors/{$this->monitorId}/checkins")
-            ->withToken($this->dsn, 'DSN');
+        $dsnString = $this->resolveDsn();
+
+        assert(is_string($dsnString), 'DSN not provided');
+
+        $dsn = Dsn::createFromString($dsnString);
+
+        $url = $dsn->getScheme() . '://';
+
+        // @see https://github.com/getsentry/develop/blob/06254d2510d16296367c8302099a40f14863193f/src/components/codeContext.tsx#L92-L96
+        $url .= str_contains($dsn->getHost(), '.ingest.')
+            ? explode('.ingest.', $dsn->getHost())[1] // SaaS
+            : $dsn->getHost(); // Self hosted
+
+        if (($dsn->getScheme() === 'http' && $dsn->getPort() !== 80)
+            || ($dsn->getScheme() === 'https' && $dsn->getPort() !== 443)) {
+            $url .= ':' . $dsn->getPort();
+        }
+
+        if ($dsn->getPath() !== null) {
+            $url .= $dsn->getPath();
+        }
+
+        return Http::baseUrl("{$url}/api/0/monitors/{$this->monitorId}/checkins")
+            ->withToken($dsnString, 'DSN');
+    }
+
+    public static function resolveDsnUsing(?Closure $callback): void
+    {
+        self::$resolveDsnCallback = $callback;
+    }
+
+
+    private function resolveDsn(): mixed
+    {
+        if (isset($this->dsn)) {
+            return $this->dsn;
+        }
+
+        if (isset(self::$resolveDsnCallback)) {
+            return call_user_func(self::$resolveDsnCallback);
+        }
+
+        return config('sentry.dsn');
     }
 
 
     public function shouldReport(): bool
     {
-        return isset($this->dsn, $this->monitorId);
+        $dsn = $this->resolveDsn();
+
+        return isset($dsn, $this->monitorId);
     }
 
 
     public function inProgress(): void
     {
-        $this->http()->post('', [
+        $this->http()->post('/', [
             'status' => 'in_progress',
         ]);
     }
@@ -44,7 +87,7 @@ class SentryReporter implements JobReporter
 
     public function success(): void
     {
-        $this->http()->put('latest', [
+        $this->http()->put('latest/', [
             'status' => 'ok',
         ]);
     }
@@ -52,7 +95,7 @@ class SentryReporter implements JobReporter
 
     public function failed(): void
     {
-        $this->http()->put('latest', [
+        $this->http()->put('latest/', [
             'status' => 'error',
         ]);
     }

--- a/src/SentryReporter.php
+++ b/src/SentryReporter.php
@@ -11,7 +11,7 @@ class SentryReporter implements JobReporter
 
 
     public function __construct(
-        protected readonly string $monitorId,
+        protected readonly ?string $monitorId,
     ) {
         $dsn = config('sentry.dsn');
 
@@ -30,7 +30,7 @@ class SentryReporter implements JobReporter
 
     public function shouldReport(): bool
     {
-        return isset($this->dsn);
+        return isset($this->dsn, $this->monitorId);
     }
 
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -28,7 +28,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $event = $this;
 
             /* @phpstan-ignore-next-line */
-
             return $event->monitor(new SentryReporter($uuid, $dsn));
         });
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,7 +22,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 ->onFailure($reporter->failed(...));
         });
 
-        Event::macro('monitorWithSentry', function (string $uuid): Event {
+        Event::macro('monitorWithSentry', function (?string $uuid): Event {
             /** @var Event $event */
             $event = $this;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Goedemiddag\ScheduleMonitor;
 
+use Goedemiddag\ScheduleMonitor\Console\SentryCommand;
 use Illuminate\Console\Scheduling\Event;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
@@ -22,12 +23,17 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 ->onFailure($reporter->failed(...));
         });
 
-        Event::macro('monitorWithSentry', function (?string $uuid): Event {
+        Event::macro('monitorWithSentry', function (?string $uuid, ?string $dsn = null): Event {
             /** @var Event $event */
             $event = $this;
 
             /* @phpstan-ignore-next-line */
-            return $event->monitor(new SentryReporter($uuid));
+
+            return $event->monitor(new SentryReporter($uuid, $dsn));
         });
+
+        $this->commands([
+            SentryCommand::class,
+        ]);
     }
 }

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -2,6 +2,7 @@
 
 namespace Goedemiddag\ScheduleMonitor\Tests;
 
+use Goedemiddag\ScheduleMonitor\SentryReporter;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Http\Client\Request;
@@ -10,6 +11,21 @@ use Mockery as m;
 
 final class SentryTest extends TestCase
 {
+    public function testShouldntReportWithoutDsn(): void
+    {
+        $monitor = new SentryReporter('foobar');
+
+        $this->assertFalse($monitor->shouldReport());
+    }
+
+
+    public function testShouldntReportWithoutMonitorId(): void
+    {
+        $monitor = new SentryReporter(null);
+
+        $this->assertFalse($monitor->shouldReport());
+    }
+
     public function testSuccessfulJob(): void
     {
         Http::fake();

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -26,13 +26,24 @@ final class SentryTest extends TestCase
         $this->assertFalse($monitor->shouldReport());
     }
 
+    public function testShouldReportWithCustomDsnResolver(): void
+    {
+        SentryReporter::resolveDsnUsing(function () {
+            return 'foobar';
+        });
+
+        $monitor = new SentryReporter('foobar');
+
+        $this->assertTrue($monitor->shouldReport());
+    }
+
     public function testSuccessfulJob(): void
     {
         Http::fake();
 
         $event = new Event(m::mock(EventMutex::class), 'exit 0', 'UTC');
 
-        config(['sentry.dsn' => 'test']);
+        config(['sentry.dsn' => 'https://token@o12345.ingest.sentry.io/67890']);
 
         $event
             ->monitorWithSentry('foobar')
@@ -41,14 +52,39 @@ final class SentryTest extends TestCase
         Http::assertSent(function (Request $request) {
             return $request->url() === 'https://sentry.io/api/0/monitors/foobar/checkins/'
                 && $request->method() === 'POST'
-                && $request->header('Authorization') === ['DSN test']
+                && $request->header('Authorization') === ['DSN https://token@o12345.ingest.sentry.io/67890']
                 && $request->body() === '{"status":"in_progress"}';
         });
 
         Http::assertSent(function (Request $request) {
-            return $request->url() === 'https://sentry.io/api/0/monitors/foobar/checkins/latest'
+            return $request->url() === 'https://sentry.io/api/0/monitors/foobar/checkins/latest/'
                 && $request->method() === 'PUT'
-                && $request->header('Authorization') === ['DSN test']
+                && $request->header('Authorization') === ['DSN https://token@o12345.ingest.sentry.io/67890']
+                && $request->body() === '{"status":"ok"}';
+        });
+    }
+
+    public function testSuccessfulJobWithCustomDsn(): void
+    {
+        Http::fake();
+
+        $event = new Event(m::mock(EventMutex::class), 'exit 0', 'UTC');
+
+        $event
+            ->monitorWithSentry('foobar', 'https://token@self-hosted.example.com/sentry/12345')
+            ->run(app());
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://self-hosted.example.com/sentry/api/0/monitors/foobar/checkins/'
+                && $request->method() === 'POST'
+                && $request->header('Authorization') === ['DSN https://token@self-hosted.example.com/sentry/12345']
+                && $request->body() === '{"status":"in_progress"}';
+        });
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://self-hosted.example.com/sentry/api/0/monitors/foobar/checkins/latest/'
+                && $request->method() === 'PUT'
+                && $request->header('Authorization') === ['DSN https://token@self-hosted.example.com/sentry/12345']
                 && $request->body() === '{"status":"ok"}';
         });
     }
@@ -59,7 +95,7 @@ final class SentryTest extends TestCase
 
         $event = new Event(m::mock(EventMutex::class), 'exit 1', 'UTC');
 
-        config(['sentry.dsn' => 'test']);
+        config(['sentry.dsn' => 'https://token@o12345.ingest.sentry.io/67890']);
 
         $event
             ->monitorWithSentry('foobar')
@@ -68,14 +104,14 @@ final class SentryTest extends TestCase
         Http::assertSent(function (Request $request) {
             return $request->url() === 'https://sentry.io/api/0/monitors/foobar/checkins/'
                 && $request->method() === 'POST'
-                && $request->header('Authorization') === ['DSN test']
+                && $request->header('Authorization') === ['DSN https://token@o12345.ingest.sentry.io/67890']
                 && $request->body() === '{"status":"in_progress"}';
         });
 
         Http::assertSent(function (Request $request) {
-            return $request->url() === 'https://sentry.io/api/0/monitors/foobar/checkins/latest'
+            return $request->url() === 'https://sentry.io/api/0/monitors/foobar/checkins/latest/'
                 && $request->method() === 'PUT'
-                && $request->header('Authorization') === ['DSN test']
+                && $request->header('Authorization') === ['DSN https://token@o12345.ingest.sentry.io/67890']
                 && $request->body() === '{"status":"error"}';
         });
     }

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -35,6 +35,9 @@ final class SentryTest extends TestCase
         $monitor = new SentryReporter('foobar');
 
         $this->assertTrue($monitor->shouldReport());
+
+        // Reset for future tests
+        SentryReporter::resolveDsnUsing(null);
     }
 
     public function testSuccessfulJob(): void


### PR DESCRIPTION
## Self-hosted Sentry
Add support for self hosted installations by determining the API endpoint from the provided DSN.

## Nullable monitor ID
To allow the user to disable the monitor or use a different monitor ID on specific environments, the monitor ID is now nullable. When null, `shouldReport` will return false.

## DSN resolver
Instead of always relying on `sentry.dsn` config being available (which may not be the case when you don't use `sentry/sentry-laravel` package), you can call `SentryReporter::resolveDsnUsing(/* closure */)` to use a different DSN. Alternatively, you can use a custom DSN for a single reporter.

## Test command
Added an Artisan command (`schedule:monitor:sentry`) to manually trigger a call to Sentry.