### PR TITLE
👷 Restore testing with prefer-lowest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         php: [ 8.1, 8.2, 8.3, 8.4 ]
         laravel: [ ^10.0, ^11.0, ^12.0, ^13.0 ]
-        stability: [ prefer-stable ]
+        stability: [ prefer-stable, prefer-lowest ]
         include:
           - laravel: ^10.0
             testbench: ^8.0

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,9 @@
   "config": {
     "allow-plugins": {
       "php-http/discovery": true
+    },
+    "audit": {
+      "block-insecure": false
     }
   }
 }


### PR DESCRIPTION
The package is not responsible for ensuring that the applications in which this package is installed don't use 'insecure' versions of other packages. For that reason, we don't want Composer to block insecure packages that are still within our dependency constraints.

Previous tests failed because of a vulnerability in Laravel 11 (below 11.44.1): https://github.com/advisories/GHSA-78fx-h6xr-vch4